### PR TITLE
fix: SignInViewでサインイン成功時にisLoadingがリセットされない問題を修正

### DIFF
--- a/DreamRecorder/Views/SignInView.swift
+++ b/DreamRecorder/Views/SignInView.swift
@@ -43,11 +43,13 @@ struct SignInView: View {
     private func signIn() async {
         isLoading = true
         errorMessage = nil
+        defer {
+            isLoading = false
+        }
         do {
             try await authManager.signInAnonymously()
         } catch {
             print("💥💥💥 サインイン失敗 (詳細): \(error) 💥💥💥")
-            isLoading = false
             errorMessage = "ログインに失敗しました。ネットワーク接続を確認してください。"
         }
     }


### PR DESCRIPTION
### **User description**
- deferブロックを使用して、成功・失敗に関わらずisLoadingをfalseに設定
- エラー時のisLoading = falseの重複を削除
- コードの一貫性を改善
(#12 )

___

### **PR Type**
Bug fix


___

### **Description**
- `defer`ブロックを使用し、`isLoading`が常に`false`にリセットされるように修正

- サインイン成功時にローディング状態が解除されないバグを修正

- エラー処理の重複コードを削除し、コードを簡潔化


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SignInView.swift</strong><dd><code>`defer`文を用いた`isLoading`状態管理の改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Views/SignInView.swift

<ul><li><code>signIn</code>関数に<code>defer</code>ブロックを導入し、処理の成功・失敗を問わず<code>isLoading</code>が<code>false</code>にリセットされることを保証しました。<br> <li> これにより、サインイン成功後もローディングインジケーターが表示され続けるバグが修正されます。<br> <li> <code>catch</code>ブロック内の冗長な<code>isLoading = false</code>の記述を削除しました。</ul>


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/21/files#diff-c49a39708b335099fc2a650ce296621ed1cadd6fe7dd88dea5cd887463893487">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

