### PR TITLE
feat: 夢と日記の一覧画面を実装し、フィルタリングとソート機能を追加

### DIFF
--- a/DreamRecorder/Views/AllDreamsView.swift
+++ b/DreamRecorder/Views/AllDreamsView.swift
@@ -162,23 +162,13 @@ private extension AllDreamsView {
             .pickerStyle(.segmented)
             .padding(.horizontal, 16)
             
-            // ソートボタン
+            // ソートボタン（タップで切り替え）
             HStack {
                 Spacer()
                 
-                Menu {
-                    ForEach(SortOrder.allCases, id: \.self) { order in
-                        Button {
-                            sortOrder = order
-                        } label: {
-                            HStack {
-                                Text(order.rawValue)
-                                if sortOrder == order {
-                                    Image(systemName: "checkmark")
-                                }
-                            }
-                        }
-                    }
+                Button {
+                    // タップで新しい順↔古い順を切り替え
+                    sortOrder = (sortOrder == .newest) ? .oldest : .newest
                 } label: {
                     HStack(spacing: 6) {
                         Image(systemName: sortOrder.icon)
@@ -326,6 +316,14 @@ private struct AllDreamsListRow: View {
     let content: String
     let recordDate: Date
     
+    /// 日付フォーマッター（短い形式: 2025/12/06）
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "yyyy/MM/dd"
+        return formatter
+    }()
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -358,7 +356,7 @@ private struct AllDreamsListRow: View {
                 .lineLimit(2)
             
             HStack {
-                Text(recordDate, style: .date)
+                Text(Self.dateFormatter.string(from: recordDate))
                     .font(.dreamCaption)
                     .foregroundColor(.dreamTextSecondary)
                 Spacer()

--- a/DreamRecorder/Views/HomeView.swift
+++ b/DreamRecorder/Views/HomeView.swift
@@ -398,6 +398,14 @@ private extension Calendar {
 private struct CompactDreamRow: View {
     let dream: Dream
     
+    /// 日付フォーマッター（短い形式: 2025/12/06）
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "yyyy/MM/dd"
+        return formatter
+    }()
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -428,7 +436,7 @@ private struct CompactDreamRow: View {
                 .lineLimit(1)
             
             HStack {
-                Text(dream.recordDate, style: .date)
+                Text(Self.dateFormatter.string(from: dream.recordDate))
                     .font(.dreamCaption)
                     .foregroundColor(.dreamTextSecondary)
                 Spacer()
@@ -453,6 +461,14 @@ private struct CompactDreamRow: View {
 
 private struct CompactReflectionRow: View {
     let reflection: Reflection
+    
+    /// 日付フォーマッター（短い形式: 2025/12/06）
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "yyyy/MM/dd"
+        return formatter
+    }()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -484,7 +500,7 @@ private struct CompactReflectionRow: View {
                 .lineLimit(1)
             
             HStack {
-                Text(reflection.recordDate, style: .date)
+                Text(Self.dateFormatter.string(from: reflection.recordDate))
                     .font(.dreamCaption)
                     .foregroundColor(.dreamTextSecondary)
                 Spacer()


### PR DESCRIPTION
### **PR Type**
Enhancement
close #28 

___

### **Description**
- 夢と日記を一覧表示する`AllDreamsView`を新規作成

- 「すべて」「夢」「日記」で絞り込むフィルタリング機能を追加

- 「新しい順」「古い順」で並び替えるソート機能を追加

- データが空の場合の表示と、読み込み中のインジケーターを実装


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph AllDreamsView
        A["フィルター/ソート コントロール"]
        B["フィルタリング & ソートロジック"]
        C["リスト表示 (List)"]
    end
    D[("DreamService")]
    E[("ReflectionService")]

    A -- "ユーザー操作" --> B
    D -- "夢データ" --> B
    E -- "日記データ" --> B
    B -- "表示用アイテム" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AllDreamsView.swift</strong><dd><code>夢と日記を一覧表示するフィルタリング・ソート機能付きのビューを実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Views/AllDreamsView.swift

<ul><li>夢と日記を統一的に扱うための<code>ListItem</code>ラッパー型を定義しました。<br> <li> 選択されたフィルター（すべて、夢、日記）とソート順（新しい順、古い順）に基づいてリストを動的に更新するロジックを実装しました。<br> <li> フィルターの状態に応じた空のリスト表示（Empty State）と、データ読み込み中のインジケーターを実装しました。<br> <li> リストの各行を表示するためのカスタムビュー<code>AllDreamsListRow</code>を定義しました。</ul>


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/35/files#diff-1bca78334d3010c88eb71f3ac41a49ced469e32cd41d1406faee0e781bcc8eb7">+356/-17</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

