### PR TITLE
feat: 夢占い画面への遷移と初期日設定を追加

### DIFF
--- a/DreamRecorder/Services/DreamService.swift
+++ b/DreamRecorder/Services/DreamService.swift
@@ -125,7 +125,7 @@ class DreamService: ObservableObject {
             
             // AIに渡すプロンプト
             let promptText: String
-            if let reflection {
+            if let reflection = reflection {
                 promptText = """
                 以下の昨日の日記と夢の内容を関連付けて分析し、500文字程度で占ってください。回答は「今日の夢占いは〜、昨日の日記を踏まえると〜」で始めてください。
 

--- a/DreamRecorder/Views/DailyDetailView.swift
+++ b/DreamRecorder/Views/DailyDetailView.swift
@@ -407,12 +407,12 @@ struct DailyDetailView: View {
                 Spacer()
                 
                 HStack(spacing: 10) {
-                    Button {
-                        Task { await reinterpret(dream: dream) }
+                    NavigationLink {
+                        DreamFortuneView(initialDate: currentDate)
                     } label: {
                         HStack(spacing: 6) {
                             Image(systemName: "sparkles")
-                            Text(dream.interpretation == nil ? "AI占い" : "再解釈")
+                            Text("夢占い")
                         }
                         .font(.system(size: 14, weight: .semibold, design: .rounded))
                         .foregroundColor(.dreamAccent)
@@ -421,7 +421,7 @@ struct DailyDetailView: View {
                         .background(Color.dreamAccent.opacity(0.18))
                         .cornerRadius(14)
                     }
-                    .disabled(isInterpreting)
+                    .buttonStyle(.plain)
 
                     Menu {
                         Button {
@@ -610,34 +610,6 @@ struct DailyDetailView: View {
     
     private func openReflectionSheet(editing reflection: Reflection?) {
         sheetContext = SheetContext(type: .reflection(reflection))
-    }
-    
-    private func reinterpret(dream: Dream) async {
-        guard let userId = authManager.userId else { return }
-        // 同日の reflection があれば渡し、占い師はデフォルトで最初の候補を使う
-        let reflectionForDay = reflectionsForDay.first
-        guard let teller = FortuneTellerManager.allFortuneTellers.first else {
-            await MainActor.run {
-                errorMessage = "占い師の設定を読み込めませんでした。"
-                showError = true
-            }
-            return
-        }
-        do {
-            try await dreamService.interpretDream(
-                dream: dream,
-                reflection: reflectionForDay,
-                teller: teller,
-                userId: userId
-            )
-        } catch {
-            let appError = ErrorLogger.classify(error, context: .ai)
-            ErrorLogger.logError(appError, context: "DailyDetailView.reinterpret")
-            await MainActor.run {
-                errorMessage = ErrorLogger.userFacingMessage(from: appError)
-                showError = true
-            }
-        }
     }
     
     private func deleteDream(_ dream: Dream) async {

--- a/DreamRecorder/Views/DreamFortuneView.swift
+++ b/DreamRecorder/Views/DreamFortuneView.swift
@@ -37,7 +37,7 @@ struct DreamFortuneView: View {
         description: "デフォルトの占い師",
         systemInstruction: ""
     )
-    @State private var selectedDate: Date = Date()
+    @State private var selectedDate: Date
     @State private var isFortuning = false
     @State private var resultText: String = ""
     @State private var errorMessage: String?
@@ -46,6 +46,10 @@ struct DreamFortuneView: View {
     @State private var fortuneAlert: FortuneAlert?
     @State private var activeSheet: FortuneSheet?
     @State private var pendingFortuneDream: Dream?
+
+    init(initialDate: Date? = nil) {
+        _selectedDate = State(initialValue: initialDate ?? Date())
+    }
     
     private var selectedDream: Dream? {
         dreamService.dreams.first { Calendar.current.isDate($0.recordDate, inSameDayAs: selectedDate) }


### PR DESCRIPTION
### **User description**
じゅんの修正も取り入れて，
詳細画面の占い部分から，夢占い画面に飛ぶように変更しました
再解釈も夢占いに変更して，夢占いに画面遷移するように変更


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- DailyDetailViewのAI占いボタンを夢占い遷移へ変更

- DreamFortuneViewに初期選択日設定機能を追加

- DreamServiceのreflectionオプショナル結合を修正


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DDV["DailyDetailView"]
  DFV["DreamFortuneView(initialDate)"]
  DDV -- "夢占いリンク" --> DFV
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DreamService.swift</strong><dd><code>reflectionオプショナル結合修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Services/DreamService.swift

- `if let reflection`を`if let reflection = reflection`に修正


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/51/files#diff-122a742422d17ef23a33f1dd895e68f556fe6ddc41e070fdbe13a7e34de5caf8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DailyDetailView.swift</strong><dd><code>AI占いボタンを夢占い遷移に変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Views/DailyDetailView.swift

<ul><li>AI占いButtonをNavigationLinkに置換<br> <li> Buttonラベルを常に「夢占い」に変更<br> <li> 再解釈機能<code>reinterpret</code>を削除<br> <li> <code>.disabled</code>削除し<code>.buttonStyle(.plain)</code>を適用</ul>


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/51/files#diff-0225154e5ef0e5c2fb2160633d4291f3a7a13280b1a77ef35832cbe857ad38af">+4/-35</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DreamFortuneView.swift</strong><dd><code>初期選択日設定機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Views/DreamFortuneView.swift

- `selectedDate`の初期値設定ロジックを修正
- `init(initialDate:)`を追加し注入可能化


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/51/files#diff-7657abae14878c520d1c90da4abdfd685cd78f7be82a49bbb73148c0f31af5e7">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

