### PR TITLE
feat: 長期分析コアとAIスコアリング機能追加

### DIFF
--- a/DreamRecorder/Models/Dream.swift
+++ b/DreamRecorder/Models/Dream.swift
@@ -2,10 +2,44 @@ import Foundation
 import FirebaseFirestore
 
 // Dream Model
-struct Dream: Identifiable, Codable {
+struct Dream: Identifiable, Codable, Equatable {
     @DocumentID var id: String?
     let content: String
     let recordDate: Date
     let createdAt: Date
     var interpretation: String?
+    
+    // 6属性分析スコア (0.0〜1.0)
+    var analysisScores: DreamAnalysisScores?
+}
+
+// MARK: - Dream Analysis Scores
+
+/// 夢の6属性分析スコア（すべて高い値=ポジティブ）
+struct DreamAnalysisScores: Codable, Equatable {
+    let serenity: Double    // 穏やかさ
+    let vitality: Double    // 活力
+    let connection: Double  // つながり
+    let creativity: Double  // 創造性
+    let security: Double    // 安心感
+    let awareness: Double   // 気づき
+    let analyzedAt: Date
+    
+    /// スコアを配列として取得（チャート描画用）
+    var asArray: [Double] {
+        [serenity, vitality, connection, creativity, security, awareness]
+    }
+    
+    /// 属性ラベル（日本語）
+    static let attributeLabels = ["穏やかさ", "活力", "つながり", "創造性", "安心感", "気づき"]
+    
+    /// 属性の説明
+    static let attributeMeanings = [
+        "心の平穏、感情の安定度を示します。",
+        "エネルギー、行動力、冒険心を示します。",
+        "人とのつながり、社会的相互作用を示します。",
+        "想像力、象徴性、非現実的要素を示します。",
+        "安心感、保護感、ストレスの少なさを示します。",
+        "夢の中での気づき、自己認識を示します。"
+    ]
 }

--- a/DreamRecorder/Services/DreamService.swift
+++ b/DreamRecorder/Services/DreamService.swift
@@ -67,8 +67,9 @@ class DreamService: ObservableObject {
         }
     }
     
-    // 夢を保存
-    func saveDream(content: String, recordDate: Date, userId: String) async throws {
+    // 夢を保存（保存したドキュメントIDを返す）
+    @discardableResult
+    func saveDream(content: String, recordDate: Date, userId: String) async throws -> String {
         guard !userId.isEmpty else {
             throw AppError.authenticationRequired
         }
@@ -79,10 +80,12 @@ class DreamService: ObservableObject {
             createdAt: Date()
         )
         
-        try db.collection("users")
+        let docRef = try db.collection("users")
             .document(userId)
             .collection("dreams")
             .addDocument(from: dream)
+        
+        return docRef.documentID
     }
     
     // 夢を削除
@@ -196,4 +199,121 @@ class DreamService: ObservableObject {
             .document(dreamId)
             .updateData(dataToUpdate)
     }
+    
+    // MARK: - 長期分析用スコア算出
+    
+    /// 夢分析スコア用のJSON Schema
+    private var analysisScoresSchema: Schema {
+        Schema.object(
+            properties: [
+                "serenity": .double(),
+                "vitality": .double(),
+                "connection": .double(),
+                "creativity": .double(),
+                "security": .double(),
+                "awareness": .double()
+            ]
+        )
+    }
+    
+    /// AI（Gemini）を使って夢の6属性スコアを分析し、Firestoreに保存する
+    /// - Note: 分析失敗時も夢の保存自体には影響しない（非クリティカルエラー）
+    func analyzeDreamScores(dreamId: String, content: String, userId: String) async {
+        do {
+            guard !userId.isEmpty else {
+                throw AppError.invalidUserId
+            }
+            
+            // AIプロンプト
+            let promptText = """
+            夢の内容を分析し、以下の6属性について0.0〜1.0のスコアで評価してください。
+            各属性は「高い値=ポジティブ」として評価してください。
+            
+            - serenity: 心の穏やかさ、感情の安定度（高い=安らぎがある）
+            - vitality: エネルギー、行動力、冒険心（高い=活動的で前向き）
+            - connection: 人とのつながり、社会的相互作用（高い=人間関係が豊か）
+            - creativity: 想像力、象徴性、非現実的要素（高い=幻想的で創造的）
+            - security: 安心感、保護感（高い=脅威がなく安心できる）
+            - awareness: 夢の中での気づき、自己認識（高い=意識的で洞察がある）
+            
+            夢の内容:
+            \(content)
+            """
+            
+            // モデルの初期化（JSON Schema を使用）
+            let model = ai.generativeModel(
+                modelName: "gemini-2.5-flash",
+                generationConfig: GenerationConfig(
+                    responseMIMEType: "application/json",
+                    responseSchema: analysisScoresSchema
+                ),
+                systemInstruction: ModelContent(role: "system", parts: "あなたは夢分析の専門家です。夢の内容を客観的に分析し、各属性のスコアを返してください。")
+            )
+            
+            let userContent = ModelContent(role: "user", parts: promptText)
+            let response = try await model.generateContent([userContent])
+            
+            guard let responseText = response.text else {
+                throw AppError.aiServiceError("AIからの応答が空でした。")
+            }
+            
+            // JSONをデコード（responseSchemaにより確実にJSON形式で返ってくる）
+            guard let jsonData = responseText.data(using: .utf8) else {
+                throw AppError.aiServiceError("JSONデータの変換に失敗しました。")
+            }
+            
+            let decoded = try JSONDecoder().decode(AnalysisScoresResponse.self, from: jsonData)
+            
+            // スコアをクランプしてDreamAnalysisScoresを作成
+            let scores = DreamAnalysisScores(
+                serenity: clampScore(decoded.serenity),
+                vitality: clampScore(decoded.vitality),
+                connection: clampScore(decoded.connection),
+                creativity: clampScore(decoded.creativity),
+                security: clampScore(decoded.security),
+                awareness: clampScore(decoded.awareness),
+                analyzedAt: Date()
+            )
+            
+            // Firestoreに保存
+            let scoresData: [String: Any] = [
+                "analysisScores": [
+                    "serenity": scores.serenity,
+                    "vitality": scores.vitality,
+                    "connection": scores.connection,
+                    "creativity": scores.creativity,
+                    "security": scores.security,
+                    "awareness": scores.awareness,
+                    "analyzedAt": Timestamp(date: scores.analyzedAt)
+                ]
+            ]
+            
+            try await db.collection("users")
+                .document(userId)
+                .collection("dreams")
+                .document(dreamId)
+                .updateData(scoresData)
+            
+        } catch {
+            // 非クリティカルエラー：ログ記録のみ、ユーザーには通知しない
+            let appError = ErrorLogger.classify(error, context: .ai)
+            ErrorLogger.logError(appError, context: "DreamService.analyzeDreamScores")
+        }
+    }
+    
+    /// スコアを0.0〜1.0の範囲にクランプ
+    private func clampScore(_ value: Double) -> Double {
+        max(0.0, min(1.0, value))
+    }
+}
+
+// MARK: - AI Response Model
+
+private struct AnalysisScoresResponse: Decodable {
+    let serenity: Double
+    let vitality: Double
+    let connection: Double
+    let creativity: Double
+    let security: Double
+    let awareness: Double
 }

--- a/DreamRecorder/Views/AddDreamView.swift
+++ b/DreamRecorder/Views/AddDreamView.swift
@@ -276,13 +276,33 @@ struct AddDreamView: View {
                     resetInterpretation: resetInterpretation, // ⇐ アラートの結果を渡す
                     userId: userId
                 )
+                
+                // 内容が変更された場合は再分析（バックグラウンドで実行）
+                if resetInterpretation, let dreamId = dreamToEdit.id {
+                    Task {
+                        await dreamService.analyzeDreamScores(
+                            dreamId: dreamId,
+                            content: content,
+                            userId: userId
+                        )
+                    }
+                }
             } else {
                 // 追加モード
-                try await dreamService.saveDream(
+                let dreamId = try await dreamService.saveDream(
                     content: content,
                     recordDate: self.recordDate,
                     userId: userId
                 )
+                
+                // 保存後にバックグラウンドで6属性分析を実行
+                Task {
+                    await dreamService.analyzeDreamScores(
+                        dreamId: dreamId,
+                        content: content,
+                        userId: userId
+                    )
+                }
             }
             
             await MainActor.run {

--- a/DreamRecorder/Views/LongTermAnalysisView.swift
+++ b/DreamRecorder/Views/LongTermAnalysisView.swift
@@ -1,77 +1,131 @@
 import SwiftUI
 
-private struct CoreParameters {
-    var emotion: Double
-    var action: Double
-    var social: Double
-    var fantasy: Double
-    var chaos: Double
-    var lucidity: Double
-    
-    var asArray: [Double] { [emotion, action, social, fantasy, chaos, lucidity] }
-    
-    static var mockCurrent: CoreParameters {
-        CoreParameters(emotion: 0.68, action: 0.55, social: 0.48, fantasy: 0.71, chaos: 0.42, lucidity: 0.64)
-    }
-    
-    static var mockPrevious: CoreParameters {
-        CoreParameters(emotion: 0.52, action: 0.61, social: 0.45, fantasy: 0.58, chaos: 0.54, lucidity: 0.59)
-    }
-}
-
-private struct DreamAnalysisData {
-    var current: CoreParameters
-    var previous: CoreParameters
-    var advice: String
-    
-    static var mock: DreamAnalysisData {
-        DreamAnalysisData(
-            current: .mockCurrent,
-            previous: .mockPrevious,
-            advice: "今月は静かな創造力が高まりつつあります。感情と覚醒のバランスを保ちながら、少しだけ行動を増やすと輝きが強くなりそうです。"
-        )
-    }
-}
-
 struct LongTermAnalysisView: View {
     @EnvironmentObject private var dreamService: DreamService
+    @EnvironmentObject private var authManager: AuthManager
     
+    @StateObject private var viewModel = LongTermAnalysisViewModel()
     @AppStorage("showMonthlyComparison") private var showComparison = true
-    @State private var analysisData: DreamAnalysisData = .mock
     @State private var showAttributeGuide = false
     
-    private let attributeLabels = ["平穏", "活動", "絆", "創造", "ストレス", "気づき"]
-    private let highlightColor = Color.dreamAccent
+    // エラーハンドリング用（ERROR_HANDLING_GUIDE.md準拠）
+    @State private var showError = false
+    @State private var errorMessage = ""
     
-    private var attributeMeanings: [String] {
-        [
-            "感情の深さや共感、心の動きを映す軸です。",
-            "行動力や前進の勢いを示す軸です。",
-            "人とのつながりや支え合いを示す軸です。",
-            "想像力や創造性、魔法のような発想力を示す軸です。",
-            "予測不能さやストレス、試練の揺らぎを示す軸です。",
-            "夢の中での気づきや俯瞰力、落ち着きを示す軸です。"
-        ]
-    }
+    private let highlightColor = Color.dreamAccent
     
     var body: some View {
         NavigationStack {
             ZStack(alignment: .top) {
                 Color.clear.dreamBackground()
 
-                VStack(spacing: 12) {
-                    longTermSection
+                ScrollView {
+                    VStack(spacing: 12) {
+                        if viewModel.hasEnoughData {
+                            longTermSection
+                        } else {
+                            insufficientDataSection
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 12)
                 }
-                .padding(.horizontal)
-                .padding(.vertical, 12)
             }
-        .navigationTitle("長期分析")
-        .navigationBarTitleDisplayMode(.inline)
-        .sheet(isPresented: $showAttributeGuide) {
+            .navigationTitle("長期分析")
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showAttributeGuide) {
                 attributeGuideSheet
+            }
+            .alert("エラー", isPresented: $showError) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(errorMessage)
+            }
+            // Service監視（パターンA）
+            .onChange(of: dreamService.errorMessage) { _, newValue in
+                if let error = newValue {
+                    errorMessage = error
+                    showError = true
+                    dreamService.errorMessage = nil
+                }
+            }
+            // ViewModel監視
+            .onChange(of: viewModel.errorMessage) { _, newValue in
+                if let error = newValue {
+                    errorMessage = error
+                    showError = true
+                    viewModel.errorMessage = nil
+                }
+            }
+            // 夢データが更新されたらスコアを再計算
+            .onChange(of: dreamService.dreams) { _, newDreams in
+                viewModel.calculateMonthlyScores(dreams: newDreams)
+            }
+            .onAppear {
+                viewModel.calculateMonthlyScores(dreams: dreamService.dreams)
             }
         }
     }
+    
+    // MARK: - Insufficient Data Section
+    
+    private var insufficientDataSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("夢の星座")
+                    .font(.system(.headline, design: .rounded, weight: .semibold))
+                    .foregroundColor(.dreamText)
+                Spacer()
+                Button {
+                    showAttributeGuide = true
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 24))
+                        .foregroundColor(.dreamAccent)
+                }
+            }
+            
+            VStack(spacing: 16) {
+                Image(systemName: "moon.stars")
+                    .font(.system(size: 48))
+                    .foregroundColor(.dreamTextSecondary)
+                
+                Text("分析にはもう少し夢の記録が必要です")
+                    .font(.system(.body, design: .rounded, weight: .semibold))
+                    .foregroundColor(.dreamText)
+                    .multilineTextAlignment(.center)
+                
+                let remaining = LongTermAnalysisViewModel.minimumDreamCount - viewModel.analyzedDreamCount
+                Text("あと\(max(0, remaining))件の夢を記録すると、\n6属性の分析結果が表示されます。")
+                    .font(.dreamCaption)
+                    .foregroundColor(.dreamTextSecondary)
+                    .multilineTextAlignment(.center)
+                
+                if viewModel.analyzedDreamCount > 0 {
+                    HStack(spacing: 4) {
+                        ForEach(0..<LongTermAnalysisViewModel.minimumDreamCount, id: \.self) { index in
+                            Circle()
+                                .fill(index < viewModel.analyzedDreamCount ? highlightColor : Color.white.opacity(0.2))
+                                .frame(width: 8, height: 8)
+                        }
+                    }
+                    .padding(.top, 8)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 40)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.dreamCard)
+        .cornerRadius(16)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    }
+    
+    // MARK: - Long Term Section
     
     private var longTermSection: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -89,35 +143,27 @@ struct LongTermAnalysisView: View {
                 }
             }
             
-            Text("過去の夢を6属性でマッピングし、星座のように可視化します。")
+            Text("今月の夢を6属性でマッピングし、星座のように可視化します。")
                 .font(.dreamCaption)
                 .foregroundColor(.dreamTextSecondary)
             
+            // 月間比較トグル
+            if viewModel.previousMonthScores != nil {
+                Toggle("先月と比較", isOn: $showComparison)
+                    .font(.dreamCaption)
+                    .foregroundColor(.dreamTextSecondary)
+                    .tint(.dreamAccent)
+            }
+            
             DreamConstellationChart(
-                current: analysisData.current.asArray,
-                previous: showComparison ? analysisData.previous.asArray : [],
-                labels: attributeLabels,
+                current: viewModel.currentMonthScores?.asArray ?? [],
+                previous: showComparison ? (viewModel.previousMonthScores?.asArray ?? []) : [],
+                labels: DreamAnalysisScores.attributeLabels,
                 highlightColor: highlightColor
             )
             .frame(height: 300)
             
-            VStack(alignment: .leading, spacing: 8) {
-                let strongestIndex = analysisData.current.asArray.enumerated().max(by: { $0.element < $1.element })?.offset ?? 0
-                let strongestLabel = attributeLabels[safe: strongestIndex] ?? ""
-                
-                Text("分析結果")
-                    .font(.dreamBody)
-                    .foregroundColor(.dreamTextSecondary)
-                Text("今月は \(strongestLabel) の輝きが強いですね！")
-                    .font(.system(.callout, design: .rounded, weight: .semibold))
-                    .foregroundColor(highlightColor)
-                Text(analysisData.advice)
-                    .font(.system(.callout, design: .rounded))
-                    .foregroundColor(.dreamText)
-            }
-            .padding(12)
-            .background(Color.black.opacity(0.3))
-            .cornerRadius(12)
+            analysisResultSection
         }
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -128,6 +174,68 @@ struct LongTermAnalysisView: View {
                 .stroke(Color.white.opacity(0.08), lineWidth: 1)
         )
     }
+    
+    // MARK: - Analysis Result Section
+    
+    private var analysisResultSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("分析結果")
+                    .font(.dreamBody)
+                    .foregroundColor(.dreamTextSecondary)
+                
+                Spacer()
+                
+                if viewModel.aiAdvice == nil && !viewModel.isGeneratingAdvice {
+                    Button {
+                        Task {
+                            await viewModel.generateAdvice()
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "sparkles")
+                            Text("アドバイスを生成")
+                        }
+                        .font(.dreamCaption)
+                    }
+                    .buttonStyle(.borderless)
+                    .tint(.dreamAccent)
+                }
+            }
+            
+            if let scores = viewModel.currentMonthScores {
+                let strongestLabel = DreamAnalysisScores.attributeLabels[safe: scores.strongestIndex] ?? ""
+                Text("今月は「\(strongestLabel)」の輝きが強いですね！")
+                    .font(.system(.callout, design: .rounded, weight: .semibold))
+                    .foregroundColor(highlightColor)
+                
+                Text("\(scores.dreamCount)件の夢を分析しました")
+                    .font(.dreamCaption)
+                    .foregroundColor(.dreamTextSecondary)
+            }
+            
+            if viewModel.isGeneratingAdvice {
+                HStack {
+                    ProgressView()
+                        .tint(.dreamAccent)
+                    Text("アドバイスを生成中...")
+                        .font(.dreamCaption)
+                        .foregroundColor(.dreamTextSecondary)
+                }
+                .padding(.top, 4)
+            } else if let advice = viewModel.aiAdvice {
+                Text(advice)
+                    .font(.system(.callout, design: .rounded))
+                    .foregroundColor(.dreamText)
+                    .padding(.top, 4)
+            }
+        }
+        .padding(12)
+        .background(Color.black.opacity(0.3))
+        .cornerRadius(12)
+    }
+    
+    // MARK: - Attribute Guide Sheet
     
     private var attributeGuideSheet: some View {
         NavigationStack {
@@ -142,8 +250,11 @@ struct LongTermAnalysisView: View {
                             .foregroundColor(.dreamTextSecondary)
                             .padding(.bottom, 8)
                         
-                        ForEach(Array(attributeLabels.enumerated()), id: \.offset) { index, label in
-                            attributeCard(label: label, meaning: attributeMeanings[safe: index] ?? "")
+                        ForEach(Array(DreamAnalysisScores.attributeLabels.enumerated()), id: \.offset) { index, label in
+                            attributeCard(
+                                label: label,
+                                meaning: DreamAnalysisScores.attributeMeanings[safe: index] ?? ""
+                            )
                         }
                     }
                     .padding()
@@ -205,20 +316,22 @@ private struct DreamConstellationChart: View {
             let count = min(current.count, labels.count)
             
             ZStack {
-                grid(center: center, radius: radius, count: count)
-                
-                if !previous.isEmpty {
-                    polygonPath(values: previous, center: center, radius: radius, count: count)
-                        .stroke(Color.white.opacity(0.3), style: StrokeStyle(lineWidth: 1.2, lineJoin: .round, dash: [6, 6]))
+                if count > 0 {
+                    grid(center: center, radius: radius, count: count)
+                    
+                    if !previous.isEmpty {
+                        polygonPath(values: previous, center: center, radius: radius, count: count)
+                            .stroke(Color.white.opacity(0.3), style: StrokeStyle(lineWidth: 1.2, lineJoin: .round, dash: [6, 6]))
+                    }
+                    
+                    polygonPath(values: current, center: center, radius: radius, count: count)
+                        .stroke(highlightColor.opacity(0.9), style: StrokeStyle(lineWidth: 2.2, lineJoin: .round))
+                        .shadow(color: highlightColor.opacity(0.5), radius: 6, x: 0, y: 0)
+                    
+                    starNodes(values: current, center: center, radius: radius, count: count)
+                    
+                    labelLayer(center: center, radius: radius, count: count)
                 }
-                
-                polygonPath(values: current, center: center, radius: radius, count: count)
-                    .stroke(highlightColor.opacity(0.9), style: StrokeStyle(lineWidth: 2.2, lineJoin: .round))
-                    .shadow(color: highlightColor.opacity(0.5), radius: 6, x: 0, y: 0)
-                
-                starNodes(values: current, center: center, radius: radius, count: count)
-                
-                labelLayer(center: center, radius: radius, count: count)
             }
             .frame(width: geo.size.width, height: geo.size.height)
         }

--- a/DreamRecorder/Views/LongTermAnalysisViewModel.swift
+++ b/DreamRecorder/Views/LongTermAnalysisViewModel.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+import Combine
+import FirebaseAI
+
+// MARK: - Average Scores
+
+/// 月間の平均スコア
+struct AverageScores: Equatable {
+    let serenity: Double
+    let vitality: Double
+    let connection: Double
+    let creativity: Double
+    let security: Double
+    let awareness: Double
+    let dreamCount: Int
+    
+    var asArray: [Double] {
+        [serenity, vitality, connection, creativity, security, awareness]
+    }
+    
+    /// 最も高いスコアの属性インデックスを取得
+    var strongestIndex: Int {
+        asArray.enumerated().max(by: { $0.element < $1.element })?.offset ?? 0
+    }
+    
+    /// 最も低いスコアの属性インデックスを取得
+    var weakestIndex: Int {
+        asArray.enumerated().min(by: { $0.element < $1.element })?.offset ?? 0
+    }
+    
+    static var empty: AverageScores {
+        AverageScores(serenity: 0, vitality: 0, connection: 0, creativity: 0, security: 0, awareness: 0, dreamCount: 0)
+    }
+}
+
+// MARK: - ViewModel
+
+@MainActor
+class LongTermAnalysisViewModel: ObservableObject {
+    @Published var currentMonthScores: AverageScores?
+    @Published var previousMonthScores: AverageScores?
+    @Published var aiAdvice: String?
+    @Published var isGeneratingAdvice = false
+    @Published var errorMessage: String?
+    
+    private let ai = FirebaseAI.firebaseAI(backend: .googleAI())
+    
+    /// 分析に必要な最低夢数
+    static let minimumDreamCount = 3
+    
+    /// 現在の月の夢が分析可能かどうか
+    var hasEnoughData: Bool {
+        guard let scores = currentMonthScores else { return false }
+        return scores.dreamCount >= Self.minimumDreamCount
+    }
+    
+    /// 分析済みの夢数
+    var analyzedDreamCount: Int {
+        currentMonthScores?.dreamCount ?? 0
+    }
+    
+    // MARK: - Monthly Score Calculation
+    
+    /// 夢リストから月間スコアを計算
+    func calculateMonthlyScores(dreams: [Dream]) {
+        let calendar = Calendar.current
+        let now = Date()
+        
+        // 当月の範囲を取得
+        guard let currentMonthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: now)),
+              let previousMonthStart = calendar.date(byAdding: .month, value: -1, to: currentMonthStart),
+              let currentMonthEnd = calendar.date(byAdding: .month, value: 1, to: currentMonthStart) else {
+            return
+        }
+        
+        // 当月の夢をフィルタリング（分析スコアがあるもののみ）
+        let currentMonthDreams = dreams.filter { dream in
+            dream.recordDate >= currentMonthStart &&
+            dream.recordDate < currentMonthEnd &&
+            dream.analysisScores != nil
+        }
+        
+        // 前月の夢をフィルタリング
+        let previousMonthDreams = dreams.filter { dream in
+            dream.recordDate >= previousMonthStart &&
+            dream.recordDate < currentMonthStart &&
+            dream.analysisScores != nil
+        }
+        
+        // スコアを集計
+        currentMonthScores = calculateAverageScores(from: currentMonthDreams)
+        previousMonthScores = calculateAverageScores(from: previousMonthDreams)
+    }
+    
+    /// 夢リストから平均スコアを計算
+    private func calculateAverageScores(from dreams: [Dream]) -> AverageScores? {
+        let scoredDreams = dreams.compactMap { $0.analysisScores }
+        guard !scoredDreams.isEmpty else { return nil }
+        
+        let count = Double(scoredDreams.count)
+        
+        let avgSerenity = scoredDreams.reduce(0) { $0 + $1.serenity } / count
+        let avgVitality = scoredDreams.reduce(0) { $0 + $1.vitality } / count
+        let avgConnection = scoredDreams.reduce(0) { $0 + $1.connection } / count
+        let avgCreativity = scoredDreams.reduce(0) { $0 + $1.creativity } / count
+        let avgSecurity = scoredDreams.reduce(0) { $0 + $1.security } / count
+        let avgAwareness = scoredDreams.reduce(0) { $0 + $1.awareness } / count
+        
+        return AverageScores(
+            serenity: avgSerenity,
+            vitality: avgVitality,
+            connection: avgConnection,
+            creativity: avgCreativity,
+            security: avgSecurity,
+            awareness: avgAwareness,
+            dreamCount: scoredDreams.count
+        )
+    }
+    
+    // MARK: - AI Advice Generation
+    
+    /// 月間傾向に基づいてAIアドバイスを生成
+    func generateAdvice() async {
+        guard let current = currentMonthScores else {
+            errorMessage = "分析データが不足しています。"
+            return
+        }
+        
+        isGeneratingAdvice = true
+        errorMessage = nil
+        
+        do {
+            let labels = DreamAnalysisScores.attributeLabels
+            let strongestLabel = labels[safe: current.strongestIndex] ?? "不明"
+            let weakestLabel = labels[safe: current.weakestIndex] ?? "不明"
+            
+            var promptText = """
+            ユーザーの夢の月間分析結果に基づいて、優しく励ますようなアドバイスを150文字程度で生成してください。
+            
+            今月のスコア（0.0〜1.0）:
+            - 穏やかさ: \(String(format: "%.2f", current.serenity))
+            - 活力: \(String(format: "%.2f", current.vitality))
+            - つながり: \(String(format: "%.2f", current.connection))
+            - 創造性: \(String(format: "%.2f", current.creativity))
+            - 安心感: \(String(format: "%.2f", current.security))
+            - 気づき: \(String(format: "%.2f", current.awareness))
+            
+            最も高い属性: \(strongestLabel)
+            最も低い属性: \(weakestLabel)
+            分析した夢の数: \(current.dreamCount)件
+            """
+            
+            // 前月のスコアがあれば比較情報を追加
+            if let previous = previousMonthScores {
+                promptText += """
+                
+                
+                先月のスコア:
+                - 穏やかさ: \(String(format: "%.2f", previous.serenity))
+                - 活力: \(String(format: "%.2f", previous.vitality))
+                - つながり: \(String(format: "%.2f", previous.connection))
+                - 創造性: \(String(format: "%.2f", previous.creativity))
+                - 安心感: \(String(format: "%.2f", previous.security))
+                - 気づき: \(String(format: "%.2f", previous.awareness))
+                
+                先月との変化も踏まえてアドバイスしてください。
+                """
+            }
+            
+            let model = ai.generativeModel(
+                modelName: "gemini-2.5-flash",
+                systemInstruction: ModelContent(role: "system", parts: "あなたは優しい夢分析カウンセラーです。ユーザーの夢の傾向から、ポジティブで励ましになるアドバイスを提供してください。")
+            )
+            
+            let userContent = ModelContent(role: "user", parts: promptText)
+            let response = try await model.generateContent([userContent])
+            
+            guard let adviceText = response.text else {
+                throw AppError.aiServiceError("AIからの応答が空でした。")
+            }
+            
+            aiAdvice = adviceText
+            
+        } catch {
+            let appError = ErrorLogger.classify(error, context: .ai)
+            ErrorLogger.logError(appError, context: "LongTermAnalysisViewModel.generateAdvice")
+            errorMessage = ErrorLogger.userFacingMessage(from: appError)
+        }
+        
+        isGeneratingAdvice = false
+    }
+}
+
+// MARK: - Safe Array Access
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard indices.contains(index) else { return nil }
+        return self[index]
+    }
+}


### PR DESCRIPTION
### **User description**
# 長期分析機能の実装

## 要点
- LongTermAnalysisViewModelを追加（月間スコア計算とAIアドバイス生成）
- モックデータから実際のデータを使用するように変更
- データ不足時のUI表示を追加
- 月間比較機能を実装
- AIアドバイス生成機能を追加
- エラーハンドリングを実装

## 概要
夢の記録を6属性（穏やかさ、活力、つながり、創造性、安心感、気づき）で分析し、レーダーチャート（夢の星座）として可視化する機能を実装しました。

## 主な変更内容
- 長期分析画面（`LongTermAnalysisView`）の追加
- 月間スコアの集計と可視化
- 前月との比較機能
- AIによるアドバイス生成機能

## テスト方法

⚠️ **重要：この機能をテストするには、分析スコアが付いた夢が最低3件必要です。**

### テスト手順

1. **新規夢を追加する場合**
   - ホーム画面から新しい夢を3件以上追加してください
   - 各夢を保存すると、自動的に6属性の分析スコアが付与されます
   - 長期分析タブに移動すると、レーダーチャートが表示されます

2. **既存の夢を編集する場合**
   - 既存の夢を3件以上開いて編集・保存してください
   - 保存時に分析スコアが再計算されます
   - 長期分析タブで結果を確認できます

### 確認ポイント
- [ ] 夢が3件未満の場合、「分析にはもう少し夢の記録が必要です」というメッセージが表示される
- [ ] 夢が3件以上ある場合、レーダーチャート（夢の星座）が表示される
- [x] 前月のデータがある場合、「先月と比較」トグルで比較表示ができる
- [x] 「アドバイスを生成」ボタンでAIアドバイスが生成される
- [x] 属性ガイド（infoアイコン）で各属性の説明が確認できる

## 技術的な詳細
- 分析に必要な最低夢数: 3件（`LongTermAnalysisViewModel.minimumDreamCount`）
- 分析対象: 現在の月の夢で、`analysisScores` が設定されているもの
- 可視化: 6属性をレーダーチャート形式で表示


___

### **PR Type**
Enhancement


___

### **Description**
- 夢モデルに6属性分析スコア追加

- DreamServiceにAI分析・Firestore保存機能追加

- 夢保存・編集後に自動分析をバックグラウンド実行

- 長期分析画面とViewModelを実装


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add/Edit Dream"] -- "保存イベント" --> B["DreamService.saveDream"]
  B -- "返却IDを返却" --> C["DreamService.analyzeDreamScores"]
  C -- "スコア算出＆Firestore保存" --> D["FirestoreにanalysisScores更新"]
  D -- "データ更新通知" --> E["LongTermAnalysisViewModel.calculateMonthlyScores"]
  E -- "UI描画更新" --> F["LongTermAnalysisView"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dream.swift</strong><dd><code>夢モデルに6属性分析スコア追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Models/Dream.swift

<ul><li><code>Dream</code>に<code>analysisScores</code>プロパティを追加<br> <li> <code>DreamAnalysisScores</code>構造体を定義<br> <li> スコア配列変換用<code>asArray</code>を追加<br> <li> 属性ラベルと説明を定義</ul>


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/52/files#diff-8da8e2a149f66b504e4ce7c0acb8c267bd6364d13f61e631a4bf749fe8a382ad">+35/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DreamService.swift</strong><dd><code>DreamServiceにAIスコア分析機能追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Services/DreamService.swift

<ul><li><code>saveDream</code>がドキュメントIDを返却するよう変更<br> <li> <code>analyzeDreamScores</code>メソッドを追加<br> <li> JSON SchemaでAIレスポンスを構造化<br> <li> 非クリティカルエラーはログのみ記録</ul>


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/52/files#diff-122a742422d17ef23a33f1dd895e68f556fe6ddc41e070fdbe13a7e34de5caf8">+123/-3</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AddDreamView.swift</strong><dd><code>AddDreamViewに自動スコア分析呼び出し追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Views/AddDreamView.swift

- 夢保存後に`analyzeDreamScores`をバックグラウンド実行
- 編集時の内容変更で再分析を実行


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/52/files#diff-d7bb8c6dd8491d56a5ae8674b90667d84cb28320f6589f991ab8dc314d4b3876">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LongTermAnalysisView.swift</strong><dd><code>長期分析画面をViewModel対応で実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Views/LongTermAnalysisView.swift

<ul><li><code>LongTermAnalysisViewModel</code>を導入しリファクタリング<br> <li> データ不足・分析結果セクションを追加<br> <li> トグルとエラーハンドリングUIを実装</ul>


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/52/files#diff-ff5b74e940f207650eb056c9ea2a59ddb5b10a2f502810a2e4579d968bce58b0">+202/-89</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LongTermAnalysisViewModel.swift</strong><dd><code>長期分析用ViewModelを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DreamRecorder/Views/LongTermAnalysisViewModel.swift

<ul><li><code>LongTermAnalysisViewModel</code>を追加<br> <li> 月間平均スコア算出ロジックを実装<br> <li> AIによるアドバイス生成機能を追加</ul>


</details>


  </td>
  <td><a href="https://github.com/jun-kb/DreamRecorder/pull/52/files#diff-c132d63ee105fb49bcb604f9af8b5012851fd71dfbf6d6de156486fb985c5691">+201/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

